### PR TITLE
Integrate build-parent-toc

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -24,7 +24,7 @@ function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPref
   if (updateOnly) {
     console.log('--update-only flag is enabled. Only updating files that already have a TOC.')
   }
-  
+
   console.log('\n==================\n');
 
   var transformed = files

--- a/doctoc.js
+++ b/doctoc.js
@@ -2,11 +2,12 @@
 
 'use strict';
 
-var path      =  require('path')
-  , fs        =  require('fs')
-  , minimist  =  require('minimist')
-  , file      =  require('./lib/file')
-  , transform =  require('./lib/transform')
+var path          =  require('path')
+  , fs            =  require('fs')
+  , minimist      =  require('minimist')
+  , file          =  require('./lib/file')
+  , transform     =  require('./lib/transform')
+  , processFolder =  require('./lib/build-parent-toc')
   , files;
 
 function cleanPath(path) {
@@ -16,7 +17,7 @@ function cleanPath(path) {
   return homeExpanded.replace(/\s/g, '\\ ');
 }
 
-function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly) {
+function addTocToFiles(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly) {
   if (processAll) {
     console.log('--all flag is enabled. Including headers before the TOC location.')
   }
@@ -58,11 +59,32 @@ function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPref
   });
 }
 
+function addParentTocs(folder) {
+  if (!fs.existsSync(folder)) {
+    console.log(`\nBuild parent directory ${folder} does not exist.`);
+    return;
+  }
+
+  const stats = fs.statSync(folder);
+
+  if (!stats.isDirectory()) {
+    console.log(`\nBuild parent directory ${folder} is actually a file.`);
+    return;
+  }
+
+  const { changeList } = processFolder({ folder });
+
+  changeList.forEach(({ path, data }) => {
+    console.log(`${path}" will be updated`);
+    fs.writeFileSync(path, data, 'utf8');
+  });
+}
+
 function printUsageAndExit(isErr) {
 
   var outputFunc = isErr ? console.error : console.info;
 
-  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--all] [--update-only] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
+  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--all] [--update-only] [--build-parent-tocs=rootDir] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
   outputFunc('\nAvailable modes are:');
   for (var key in modes) {
     outputFunc('  --%s\t%s', key, modes[key]);
@@ -84,7 +106,7 @@ var mode = modes['github'];
 
 var argv = minimist(process.argv.slice(2)
     , { boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout', 'all' , 'u', 'update-only'].concat(Object.keys(modes))
-    , string: [ 'title', 't', 'maxlevel', 'm', 'entryprefix' ]
+    , string: [ 'title', 't', 'maxlevel', 'm', 'b', 'build-parent-tocs', 'entryprefix' ]
     , unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
     });
 
@@ -100,6 +122,7 @@ for (var key in modes) {
 
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
+var buildParentToc = argv.b || argv['build-parent-tocs'];
 var entryPrefix = argv.entryprefix || '-';
 var processAll = argv.all;
 var stdOut = argv.s || argv.stdout
@@ -120,9 +143,14 @@ for (var i = 0; i < argv._.length; i++) {
     files = [{ path: target }];
   }
 
-  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly);
+  addTocToFiles(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly);
 
   console.log('\nEverything is OK.');
+}
+
+if (buildParentToc) {
+  const parentTarget = cleanPath(buildParentToc);
+  addParentTocs(parentTarget, mode);
 }
 
 module.exports.transform = transform;

--- a/lib/build-parent-toc.js
+++ b/lib/build-parent-toc.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var path = require('path'),
+    fs = require('fs'),
+    transform = require('../doctoc/lib/transform');
+
+const markdownExts = ['.md', '.markdown'];
+// const ignoredFiles = ['README.md'];
+const ignoredFolders = ['.git', '.vscode', 'node_modules']
+const tocHeader = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n'
+                + '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->\n'
+                + 'Table of Contents\n\n',
+      tocFooter = '\n<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
+
+
+function processFolder(path, folder) {
+  let tocs = "";
+
+  const folderPath = path + folder;
+
+  if (fs.existsSync(`${folderPath}/README.md`)) {
+    tocs = processFile(folderPath, 'README.md');
+  }
+
+  const children = getChildren(folderPath),
+    folders = children[0],
+    files = children[1];
+
+  folders.forEach((childFolder) => {
+    tocs += processFolder(folderPath + '/', childFolder);
+  });
+
+  files.forEach((file) => {
+    if (!file.endsWith('README.md')) {
+      tocs += processFile(folderPath, file);
+    }
+  });
+
+  writeTocsToReadMe(folderPath, tocs);
+
+  return prependNameOfFolder(folder, tocs);
+}
+
+processFolder('', '.');
+
+function getChildren(folder) {
+  let folders = [], files = [];
+
+  var children = fs.readdirSync(folder);
+
+  for (let index = 0; index < children.length; index++) {
+    var childName = children[index];
+
+    if (ignoredFolders.includes(childName)) {
+      continue;
+    }
+
+    var filePathString = folder + '/' + childName;
+
+    if (fs.statSync(filePathString).isDirectory()) {
+      folders.push(childName);
+    } else if (markdownExts.includes(path.extname(childName))) {
+      files.push(childName);
+    }
+  }
+
+  return [folders, files];
+}
+
+function processFile(path, file) {
+  let toc = transform(fs.readFileSync(path + '/' + file, 'utf8'), 'github.com', 12).toc;
+
+  if (!toc) {
+    return '';
+  }
+
+  toc = toc.replace('Table of Contents\n\n', '');
+
+  if (!file.endsWith('README.md')) {
+    toc = toc.replace(/\(#([a-z0-9\-]+)\)/gm, `(./${file}#$1)`);
+  }
+
+  toc += "\n";
+
+  return toc;
+}
+
+function writeTocsToReadMe(folder, tocs) {
+  if (fs.existsSync(`${folder}/README.md`)) {
+    console.log(`Writing to existing ${folder}/README.md`);
+    let fileData = fs.readFileSync(`${folder}/README.md`, 'utf8').replace(/(Table of Contents\n).*(<!-- END)/gms, `$1\n${tocs}\n$2`);
+    fs.writeFileSync(`${folder}/README.md`, fileData, 'utf8');
+  } else {
+    console.log(`Writing to non-existing ${folder}/README.md`);
+    fileData = tocHeader + tocs + tocFooter;
+    fs.writeFileSync(`${folder}/README.md`, fileData, 'utf8');
+  }
+}
+
+function prependNameOfFolder(folder, tocs) {
+  tocs = tocs.replace(/\((#[\d\w-]+)\)/gm, `(./README.md$1)`);
+  return tocs.replace(/\(\.\/*((?:[\d\w]*\/)*[\d\w-\.]+#[\d\w-]+)\)/gm, `(./${folder}/$1)`);
+}

--- a/lib/build-parent-toc.js
+++ b/lib/build-parent-toc.js
@@ -12,32 +12,44 @@ const tocHeader = '<!-- START doctoc generated TOC please keep comment here to a
                 + 'Table of Contents\n\n',
       tocFooter = '\n<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
 
-function processFolder(path, folder) {
-  let tocs = "";
-
+function processFolder({
+  folder,
+  mode = "github.com",
+  path = "",
+}) {
+  let toc = "";
+  const changeList = [];
   const folderPath = path + folder;
 
   if (fs.existsSync(`${folderPath}/README.md`)) {
-    tocs = processFile(folderPath, 'README.md');
+    toc = processFile(folderPath, 'README.md');
   }
 
-  const children = getChildren(folderPath),
-    folders = children[0],
-    files = children[1];
+  const [folders, files] = getChildren(folderPath);
 
   folders.forEach((childFolder) => {
-    tocs += processFolder(folderPath + '/', childFolder);
+    const { toc: childToc, changeList: childChangeList } = processFolder({
+      path: folderPath + '/',
+      folder: childFolder,
+    });
+
+    changeList.push(...childChangeList);
+    toc += childToc;
   });
 
   files.forEach((file) => {
     if (!file.endsWith('README.md')) {
-      tocs += processFile(folderPath, file);
+      toc += processFile(folderPath, file, mode);
     }
   });
 
-  writeTocsToReadMe(folderPath, tocs);
+  changeList.push(...generateReadmeChange(folderPath, toc));
+  toc = prependNameOfFolder(folder, toc);
 
-  return prependNameOfFolder(folder, tocs);
+  return {
+    changeList,
+    toc,
+  }
 }
 
 function getChildren(folder) {
@@ -64,8 +76,8 @@ function getChildren(folder) {
   return [folders, files];
 }
 
-function processFile(path, file) {
-  let toc = transform(fs.readFileSync(path + '/' + file, 'utf8'), 'github.com', 12).toc;
+function processFile(path, file, mode) {
+  let toc = transform(fs.readFileSync(path + '/' + file, 'utf8'), mode, 12).toc;
 
   if (!toc) {
     return '';
@@ -82,21 +94,30 @@ function processFile(path, file) {
   return toc;
 }
 
-function writeTocsToReadMe(folder, tocs) {
-  if (fs.existsSync(`${folder}/README.md`)) {
-    console.log(`Writing to existing ${folder}/README.md`);
-    let fileData = fs.readFileSync(`${folder}/README.md`, 'utf8').replace(/(Table of Contents\n).*(<!-- END)/gms, `$1\n${tocs}\n$2`);
-    fs.writeFileSync(`${folder}/README.md`, fileData, 'utf8');
+function generateReadmeChange(folder, toc) {
+  if (!toc) {
+    return []
+  }
+
+  const path = `${folder}/README.md`;
+  if (fs.existsSync(path)) {
+    const data = fs.readFileSync(path, 'utf8')
+      .replace(/(Table of Contents\n).*(<!-- END)/gms, `$1\n${toc}\n$2`);
+
+    return [{ path, data }]
   } else {
-    console.log(`Writing to non-existing ${folder}/README.md`);
-    fileData = tocHeader + tocs + tocFooter;
-    fs.writeFileSync(`${folder}/README.md`, fileData, 'utf8');
+    const data = `${tocHeader}${toc}${tocFooter}`
+    return [{ path, data }]
   }
 }
 
-function prependNameOfFolder(folder, tocs) {
-  tocs = tocs.replace(/\((#[\d\w-]+)\)/gm, `(./README.md$1)`);
-  return tocs.replace(/\(\.\/*((?:[\d\w]*\/)*[\d\w-\.]+#[\d\w-]+)\)/gm, `(./${folder}/$1)`);
+function prependNameOfFolder(folder, toc) {
+  // replace relative links to links to the readme
+  toc = toc.replace(/\((#[\w-\.]+)\)/gm, `(./README.md$1)`);
+
+  // replace existing links from the child toc to include the
+  // full folder
+  return toc.replace(/\(\.\/*((?:[\w-\.]+\/)*[\w-\.]+\.md#[\w-]+)\)/gm, `(./${folder}/$1)`);
 }
 
 module.exports = processFolder;

--- a/lib/build-parent-toc.js
+++ b/lib/build-parent-toc.js
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    transform = require('../doctoc/lib/transform');
+    transform = require('./transform');
 
 const markdownExts = ['.md', '.markdown'];
 // const ignoredFiles = ['README.md'];
@@ -11,7 +11,6 @@ const tocHeader = '<!-- START doctoc generated TOC please keep comment here to a
                 + '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->\n'
                 + 'Table of Contents\n\n',
       tocFooter = '\n<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
-
 
 function processFolder(path, folder) {
   let tocs = "";
@@ -40,8 +39,6 @@ function processFolder(path, folder) {
 
   return prependNameOfFolder(folder, tocs);
 }
-
-processFolder('', '.');
 
 function getChildren(folder) {
   let folders = [], files = [];
@@ -101,3 +98,5 @@ function prependNameOfFolder(folder, tocs) {
   tocs = tocs.replace(/\((#[\d\w-]+)\)/gm, `(./README.md$1)`);
   return tocs.replace(/\(\.\/*((?:[\d\w]*\/)*[\d\w-\.]+#[\d\w-]+)\)/gm, `(./${folder}/$1)`);
 }
+
+module.exports = processFolder;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "author": "Thorsten Lorenz <thlorenz@gmx.de> (thlorenz.com)",
+  "author": "Root Documentation Guild",
   "name": "doctoc",
   "description": "Generates TOC for markdown files of local git repo.",
   "version": "2.0.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/thlorenz/doctoc.git"
+    "url": "git://github.com/Root-App/doctoc.git"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/test/build-parent-toc.js
+++ b/test/build-parent-toc.js
@@ -1,0 +1,12 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test
+var env = require('env')
+var processFolder = require('../lib/transform')
+
+test('\nTODO', function (t) {
+  
+  t.deepEqual(true, true)
+  t.end()
+})

--- a/test/build-parent-toc.js
+++ b/test/build-parent-toc.js
@@ -2,11 +2,82 @@
 /*jshint asi: true */
 
 var test = require('tap').test
-var env = require('env')
-var processFolder = require('../lib/transform')
+var processFolder = require('../lib/build-parent-toc')
 
-test('\nTODO', function (t) {
-  
+function pickFileChange({ changeList, expectedPath }) {
+  return changeList.find(({ path }) => path === expectedPath)
+}
+
+function assertPathChanges({ t, changeList, expectations }) {
+  t.equals(expectations.length, changeList.length)
+
+  expectations.forEach(({ expectedData, expectedPath }) => {
+    const { data } = pickFileChange({ changeList, expectedPath }) ?? {};
+    t.deepEqual(data, expectedData)
+  })
+}
+
+test('\nBuild Parent Toc', function (t) {
+  const { changeList } = processFolder({
+    folder: 'test/fixtures/top-level-folder'
+  });
+
+  assertPathChanges({
+    t,
+    changeList,
+    expectations: [
+      {
+        expectedPath: 'test/fixtures/top-level-folder/mid-level-folder/low-level-folder/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          'Table of Contents',
+          '',
+          '- [This is a test document with a number](./test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '',
+          '- [This is a test document](./test_file.md#this-is-a-test-document)',
+          '',
+          '',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        ].join('\n'),
+      },
+      {
+        expectedPath: 'test/fixtures/top-level-folder/mid-level-folder/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          'Table of Contents',
+          '',
+          '- [This is a test document with a number](./low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '',
+          '- [This is a test document](./low-level-folder/test_file.md#this-is-a-test-document)',
+          '',
+          '',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        ].join('\n'),
+      },
+      {
+        expectedPath: 'test/fixtures/top-level-folder/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          'Table of Contents',
+          '',
+          '- [Top-level README](#top-level-readme)',
+          '',
+          '- [This is a test document with a number](./mid-level-folder/low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '',
+          '- [This is a test document](./mid-level-folder/low-level-folder/test_file.md#this-is-a-test-document)',
+          '',
+          '',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+          '',
+          '# Top-level README',
+        ].join('\n'),
+      },
+    ]
+  })
+
   t.deepEqual(true, true)
   t.end()
 })

--- a/test/fixtures/top-level-folder/README.md
+++ b/test/fixtures/top-level-folder/README.md
@@ -1,0 +1,9 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+Table of Contents
+
+- [Top-level README](#top-level-readme)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Top-level README

--- a/test/fixtures/top-level-folder/mid-level-folder/low-level-folder/test_file.20200412.md
+++ b/test/fixtures/top-level-folder/mid-level-folder/low-level-folder/test_file.20200412.md
@@ -1,0 +1,10 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+Table of Contents
+
+- [This is a test document with a number](#this-is-a-test-document-with-a-number)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+# This is a test document with a number

--- a/test/fixtures/top-level-folder/mid-level-folder/low-level-folder/test_file.md
+++ b/test/fixtures/top-level-folder/mid-level-folder/low-level-folder/test_file.md
@@ -1,0 +1,9 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+Table of Contents
+
+- [This is a test document](#this-is-a-test-document)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# This is a test document


### PR DESCRIPTION
## Summary
This PR integrates and tests the existing build-parent-toc script found [here](https://www.npmjs.com/package/build-parent-toc) into our fork of doctoc. 