### PR TITLE
add details block around parent TOCs

### DIFF
--- a/lib/build-parent-toc.js
+++ b/lib/build-parent-toc.js
@@ -8,8 +8,8 @@ const markdownExts = ['.md', '.markdown'];
 // const ignoredFiles = ['README.md'];
 const ignoredFolders = ['.git', '.vscode', 'node_modules']
 const tocHeader = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n'
-                + '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->\n'
-                + 'Table of Contents\n\n',
+                + '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->\n',
+      tocTitle = 'Table of Contents\n\n',
       tocFooter = '\n<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
 
 function processFolder({
@@ -99,14 +99,17 @@ function generateReadmeChange(folder, toc) {
     return []
   }
 
+  const detailsOpenBlock = '<details><summary>Full Table of Contents</summary>\n';
+  const detailsCloseBlock = '</details>'
+
   const path = `${folder}/README.md`;
   if (fs.existsSync(path)) {
     const data = fs.readFileSync(path, 'utf8')
-      .replace(/(Table of Contents\n).*(<!-- END)/gms, `$1\n${toc}\n$2`);
+      .replace(/(Table of Contents\n).*(<!-- END)/gms, `${detailsOpenBlock}\n$1\n${toc}\n${detailsCloseBlock}\n$2`);
 
     return [{ path, data }]
   } else {
-    const data = `${tocHeader}${toc}${tocFooter}`
+    const data = `${tocHeader}${detailsOpenBlock}\n${tocTitle}${toc}\n${detailsCloseBlock}${tocFooter}`
     return [{ path, data }]
   }
 }

--- a/test/build-parent-toc.js
+++ b/test/build-parent-toc.js
@@ -13,7 +13,7 @@ function assertPathChanges({ t, changeList, expectations }) {
 
   expectations.forEach(({ expectedData, expectedPath }) => {
     const { data } = pickFileChange({ changeList, expectedPath }) ?? {};
-    t.deepEqual(data, expectedData)
+    t.deepEqual(data, expectedData, expectedPath)
   })
 }
 
@@ -31,11 +31,14 @@ test('\nBuild Parent Toc', function (t) {
         expectedData: [
           '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
           '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
           'Table of Contents',
           '',
           '- [This is a test document with a number](./test_file.20200412.md#this-is-a-test-document-with-a-number)',
           '- [This is a test document](./test_file.md#this-is-a-test-document)',
           '',
+          '</details>',
           '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
         ].join('\n'),
       },
@@ -44,11 +47,14 @@ test('\nBuild Parent Toc', function (t) {
         expectedData: [
           '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
           '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
           'Table of Contents',
           '',
           '- [This is a test document with a number](./low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
           '- [This is a test document](./low-level-folder/test_file.md#this-is-a-test-document)',
           '',
+          '</details>',
           '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
         ].join('\n'),
       },
@@ -57,12 +63,15 @@ test('\nBuild Parent Toc', function (t) {
         expectedData: [
           '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
           '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
           'Table of Contents',
           '',
           '- [Top-level README](#top-level-readme)',
           '- [This is a test document with a number](./mid-level-folder/low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
           '- [This is a test document](./mid-level-folder/low-level-folder/test_file.md#this-is-a-test-document)',
           '',
+          '</details>',
           '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
           '',
           '# Top-level README',


### PR DESCRIPTION
This adds a `<details/>` block around the parent TOCs (in READMEs) so that when we move content from above the TOC to below it, it's still discoverable (instead of hidden below >3k lines of generated TOC)

[CH card](https://app.clubhouse.io/joinroot/story/126707/update-build-parent-toc-to-hide-tocs-in-a-details-block)

**note** this functionality will not be available/live in our docs until [this card](https://app.clubhouse.io/joinroot/story/125394/replace-root-engineering-docs-pre-commit-hook-with-forked-doctoc) is completed.