### PR TITLE
Restrict CI to run on node 14+

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## Problem
Today we'd like to ideally be able to use all js features without an additional buildstep in this package as long as it runs on our target node version. As of 4/20/2021 that is 14.15.2

## Solution
Limit the version of node CI runs against. In this case we remove version 10 and 12. If we later decide we want this package to be more user friendly outside of Root we can add it back to the pipeline.

This should unblock #3 and #4